### PR TITLE
Expand test coverage

### DIFF
--- a/test/graph.swift
+++ b/test/graph.swift
@@ -309,6 +309,19 @@ final class GraphTests: XCTestCase {
     XCTAssertEqual(a0.rawValue[0], 4.4 / (1.0 + exp(-4.4)), accuracy: 1e-5)
   }
 
+  func testSoftmax() throws {
+    let dynamicGraph = DynamicGraph()
+    let a0 = dynamicGraph.variable(Tensor<Float32>([1.0, 2.0, 3.0], .CPU, .C(3)))
+    a0.softmax()
+    let e0 = exp(1.0)
+    let e1 = exp(2.0)
+    let e2 = exp(3.0)
+    let sum = e0 + e1 + e2
+    XCTAssertEqual(a0.rawValue[0], Float32(e0 / sum), accuracy: 1e-5)
+    XCTAssertEqual(a0.rawValue[1], Float32(e1 / sum), accuracy: 1e-5)
+    XCTAssertEqual(a0.rawValue[2], Float32(e2 / sum), accuracy: 1e-5)
+  }
+
   func testArgmax() throws {
     let dynamicGraph = DynamicGraph()
     let a0 = dynamicGraph.variable(Tensor<Float32>([1.2, 2.2, 3.2, 3.4], .CPU, .C(4)))
@@ -407,6 +420,7 @@ final class GraphTests: XCTestCase {
     ("testSigmoid", testSigmoid),
     ("testTanh", testTanh),
     ("testSwish", testSwish),
+    ("testSoftmax", testSoftmax),
     ("testArgmax", testArgmax),
     ("testMaskedFill", testMaskedFill),
     ("testPermute", testPermute),

--- a/test/model.swift
+++ b/test/model.swift
@@ -171,6 +171,29 @@ final class ModelTests: XCTestCase {
     XCTAssertEqual(tv3s[1].rawValue[0], 0.5 / 0.2, accuracy: 1e-5)
   }
 
+  func testSoftmaxModel() throws {
+    let graph = DynamicGraph()
+    let softmax = Softmax()
+    let input = graph.variable(Tensor<Float32>([1.0, 2.0, 3.0], .CPU, .C(3)))
+    let output = DynamicGraph.Tensor<Float32>(softmax(inputs: input)[0])
+    let e0 = exp(1.0)
+    let e1 = exp(2.0)
+    let e2 = exp(3.0)
+    let sum = e0 + e1 + e2
+    XCTAssertEqual(output.rawValue[0], Float32(e0 / sum), accuracy: 1e-5)
+    XCTAssertEqual(output.rawValue[1], Float32(e1 / sum), accuracy: 1e-5)
+    XCTAssertEqual(output.rawValue[2], Float32(e2 / sum), accuracy: 1e-5)
+  }
+
+  func testLeakyReLUModel() throws {
+    let graph = DynamicGraph()
+    let model = LeakyReLU(negativeSlope: 0.1)
+    let input = graph.variable(Tensor<Float32>([1.0, -2.0], .CPU, .C(2)))
+    let output = DynamicGraph.Tensor<Float32>(model(inputs: input)[0])
+    XCTAssertEqual(output.rawValue[0], 1.0, accuracy: 1e-5)
+    XCTAssertEqual(output.rawValue[1], -0.2, accuracy: 1e-5)
+  }
+
   func testModelDebug() throws {
     let dynamicGraph = DynamicGraph()
 
@@ -485,6 +508,8 @@ final class ModelTests: XCTestCase {
     ("testModelWithScalar", testModelWithScalar),
     ("testModelWithParameter", testModelWithParameter),
     ("testModelDiv", testModelDiv),
+    ("testSoftmaxModel", testSoftmaxModel),
+    ("testLeakyReLUModel", testLeakyReLUModel),
     ("testModelDebug", testModelDebug),
     ("testModelScaledDotProductAttention", testModelScaledDotProductAttention),
     ("testCustomModel", testCustomModel),


### PR DESCRIPTION
## Summary
- cover softmax functionality on DynamicGraph tensors
- verify Softmax and LeakyReLU models

## Testing
- `bazel test //test:nnc --test_output=errors` *(fails: could not download Bazel)*