### PR TITLE
fix: change C_zlib from .target to .systemLibrary; add module.modulemap

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -38,12 +38,7 @@ let package = Package(
     // C_zlib - System zlib wrapper
     .systemLibrary(
       name: "C_zlib",
-      path: "nnc/C_zlib",
-      pkgConfig: "zlib",
-      providers: [
-        .brew(["zlib"]),
-        .apt(["zlib1g-dev"]),
-      ]
+      path: "nnc/C_zlib"
     ),
 
     // NNC - Main Swift library

--- a/Package.swift
+++ b/Package.swift
@@ -36,15 +36,13 @@ let package = Package(
   ],
   targets: [
     // C_zlib - System zlib wrapper
-    .target(
+    .systemLibrary(
       name: "C_zlib",
       path: "nnc/C_zlib",
-      publicHeadersPath: ".",
-      cSettings: [
-        .define("_GNU_SOURCE")
-      ],
-      linkerSettings: [
-        .linkedLibrary("z")
+      pkgConfig: "zlib",
+      providers: [
+        .brew(["zlib"]),
+        .apt(["zlib1g-dev"]),
       ]
     ),
 

--- a/nnc/C_zlib/module.modulemap
+++ b/nnc/C_zlib/module.modulemap
@@ -1,0 +1,5 @@
+module C_zlib [system] {
+  header "shim.h"
+  link "z"
+  export *
+}


### PR DESCRIPTION
Root cause (Xcode module name collision):
  .target(name: "C_zlib") causes Xcode to derive a Clang module named
  "C_zlib" for the build target, colliding with the system SDK's own
  zlib module. swift build CLI is unaffected because it treats SPM
  target names as internal dependency-graph identifiers and never
  independently derives Clang module names from them.

Why .systemLibrary is the correct fix (not a rename):
  zlib is a genuine system library — its binary is already on macOS/iOS.
  SPM's .systemLibrary is designed exactly for this: it tells both
  swift build and Xcode to locate and link the system-provided library
  via pkg-config / SDK rather than compiling any source. No Xcode
  build target is generated, so no module name collision occurs.

Why .systemLibrary still requires module.modulemap:
  .target: SPM compiles the C sources itself and auto-generates an
  implicit module map from publicHeadersPath — no manual map needed.

  .systemLibrary: SPM compiles nothing (the binary is already in the
  system). But when Swift code does 'import C_zlib', the compiler still
  needs to know: the module name, which headers to expose, and which
  .dylib to link. SPM cannot infer this automatically for a system
  library, so an explicit module.modulemap is required:

    module C_zlib [system] {
      header "shim.h"  // tells Clang where to find the headers
      link "z"         // tells the linker to link libz.dylib
      export *
    }

  shim.h wraps <zlib.h> with the necessary _LARGEFILE64_SOURCE /
  _FILE_OFFSET_BITS defines for 64-bit offset support.